### PR TITLE
[issue#22]把时间戳数据加到市级行政区数据中（使用该省的数据更新时间）

### DIFF
--- a/source/adapters/isaaclin.ts
+++ b/source/adapters/isaaclin.ts
@@ -39,7 +39,8 @@ function convertProvince(source): ProvinceData {
   if (source.cities && source.cities.length > 0) {
     source.cities.forEach(
       (c: { cityName: string }) =>
-        (cities[long2short(c.cityName)] = convertCity(c))
+        // 把省级的更新时间传入市级由于市级没有各自的数据更新时间
+        (cities[long2short(c.cityName)] = convertCity(c, source.updateTime))
     );
   }
   return {
@@ -50,8 +51,11 @@ function convertProvince(source): ProvinceData {
   };
 }
 
-function convertCity(source): CityData {
-  return { name: long2short(source.cityName), ...convertStat(source) };
+function convertCity(source, updateTime): CityData {
+  return {
+    name: long2short(source.cityName),
+    timestamp: updateTime, // 使用传入的省级数据更新时间
+    ...convertStat(source) };
 }
 
 export { convertCountry, convertProvince, convertCity };


### PR DESCRIPTION
按照数据格式在市级数据中加入timestamp，由于市没有数据更新时间，全部采用该省的timestamp