### PR TITLE
为折线图增加标题，显示当前统计区域

### DIFF
--- a/src/components/virusMap/virusChart.tsx
+++ b/src/components/virusMap/virusChart.tsx
@@ -314,6 +314,15 @@ export class VirusChart extends React.Component<Props, Readonly<State>> {
           height: '100%'
         }}
       >
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center'
+          }}
+        >
+          {area}疫情统计
+        </div>
         <div style={{ width: '100%', height: '50%' }}>
           <ReactEcharts
             chartOptions={this.getConfirmedSuspectChartOptions(


### PR DESCRIPTION
Why:

现在点击省市数据后，地图不做任何变化，只有统计图表变化。容易忘记选中的区域

How to fix:
增加一个title显示当前统计区域